### PR TITLE
fix: update amino serialization with fix for regen message types

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,5 +49,7 @@
     "eslint": "^7.5",
     "prettier": "^2.4.1",
     "typescript": "~4.4"
-  }
+  },
+  "packageManager": "yarn@1.22.19",
+  "version": "0.0.0"
 }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,5 @@
     "eslint": "^7.5",
     "prettier": "^2.4.1",
     "typescript": "~4.4"
-  },
-  "packageManager": "yarn@1.22.19",
-  "version": "0.0.0"
+  }
 }

--- a/packages/amino/src/signdoc.spec.ts
+++ b/packages/amino/src/signdoc.spec.ts
@@ -166,6 +166,8 @@ describe("encoding", () => {
 
       expect(parsedSignBytes.msgs[0]).toEqual(sdkAminoMsg);
       expect(parsedSignBytes.msgs[1]).toEqual(regenAminoMsg.value);
+
+      expect(signDoc.msgs[1].type).toEqual("regen.core/MsgSend")
     });
   });
 });

--- a/packages/amino/src/signdoc.spec.ts
+++ b/packages/amino/src/signdoc.spec.ts
@@ -147,9 +147,9 @@ describe("encoding", () => {
       const regenAminoMsg: AminoMsg = {
         type: "regen.core/MsgSend",
         value: {
-          from_address: testAddress,
-          to_address: makeRandomAddress(),
-          amount: [{ amount: "1234567", denom: "ecocredit" }],
+          sender: testAddress,
+          recipient: makeRandomAddress(),
+          credits: [{ '$type': 'regen.ecocredit.v1.MsgSend.SendCredits', tradableAmount: "0.01", batchDenom: "C01-001-20170606-20210601-007" }],
         },
       };
       const fee = {
@@ -165,7 +165,7 @@ describe("encoding", () => {
       const parsedSignBytes = JSON.parse(fromUtf8(serializedSignBytes));
 
       expect(parsedSignBytes.msgs[0]).toEqual(sdkAminoMsg);
-      expect(parsedSignBytes.msgs[1]).toEqual(regenAminoMsg.value);
+      expect(parsedSignBytes.msgs[1]).toEqual({...regenAminoMsg.value, credits: [{tradableAmount: "0.01", batchDenom: "C01-001-20170606-20210601-007" }]});
 
       expect(signDoc.msgs[1].type).toEqual("regen.core/MsgSend")
     });

--- a/packages/amino/src/signdoc.spec.ts
+++ b/packages/amino/src/signdoc.spec.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { Random } from "@cosmjs/crypto";
-import { toBech32 } from "@cosmjs/encoding";
+import { toBech32, fromUtf8} from "@cosmjs/encoding";
 
-import { AminoMsg, makeSignDoc, sortedJsonStringify } from "./signdoc";
+import { AminoMsg, makeSignDoc, serializeSignDoc, sortedJsonStringify } from "./signdoc";
 
 function makeRandomAddress(): string {
   return toBech32("cosmos", Random.getBytes(20));
@@ -130,6 +130,42 @@ describe("encoding", () => {
         sequence: sequence.toString(),
         memo: "",
       });
+    });
+  });
+
+  describe("serializeSignDoc", () => {
+    it("serializes regen and SDK messages differently (until regen-ledger#1480 is released)", () => {
+      const chainId = "testspace-12";
+      const sdkAminoMsg: AminoMsg = {
+        type: "cosmos-sdk/MsgDelegate",
+        value: {
+          delegator_address: testAddress,
+          validator_address: testValidatorAddress,
+          amount: { amount: "1234", denom: "ustake" },
+        },
+      };
+      const regenAminoMsg: AminoMsg = {
+        type: "regen.core/MsgSend",
+        value: {
+          from_address: testAddress,
+          to_address: makeRandomAddress(),
+          amount: [{ amount: "1234567", denom: "ecocredit" }],
+        },
+      };
+      const fee = {
+        amount: [{ amount: "2000", denom: "ucosm" }],
+        gas: "180000", // 180k
+      };
+      const memo = "Use your power wisely";
+      const accountNumber = 15;
+      const sequence = 16;
+
+      const signDoc = makeSignDoc([sdkAminoMsg, regenAminoMsg], fee, chainId, memo, accountNumber, sequence);
+      const serializedSignBytes = serializeSignDoc(signDoc)
+      const parsedSignBytes = JSON.parse(fromUtf8(serializedSignBytes));
+
+      expect(parsedSignBytes.msgs[0]).toEqual(sdkAminoMsg);
+      expect(parsedSignBytes.msgs[1]).toEqual(regenAminoMsg.value);
     });
   });
 });

--- a/packages/amino/src/signdoc.spec.ts
+++ b/packages/amino/src/signdoc.spec.ts
@@ -165,7 +165,7 @@ describe("encoding", () => {
       const parsedSignBytes = JSON.parse(fromUtf8(serializedSignBytes));
 
       expect(parsedSignBytes.msgs[0]).toEqual(sdkAminoMsg);
-      expect(parsedSignBytes.msgs[1]).toEqual({...regenAminoMsg.value, credits: [{tradableAmount: "0.01", batchDenom: "C01-001-20170606-20210601-007" }]});
+      expect(parsedSignBytes.msgs[1]).toEqual(regenAminoMsg.value);
 
       expect(signDoc.msgs[1].type).toEqual("regen.core/MsgSend")
     });

--- a/packages/amino/src/signdoc.ts
+++ b/packages/amino/src/signdoc.ts
@@ -69,5 +69,21 @@ export function makeSignDoc(
 }
 
 export function serializeSignDoc(signDoc: StdSignDoc): Uint8Array {
-  return toUtf8(sortedJsonStringify(signDoc));
+  const fixedMsgs = signDoc.msgs.map((aminoMsg) => {
+    if (aminoMsg.type.startsWith("regen")) {
+      // regen ledger incorrectly implements amino signing.
+      // this short term workaround makes cosmjs compatible with regen-ledger v4.0
+      // until regen ledger upgrades with the fix in v5.0
+      // ref: https://github.com/regen-network/regen-ledger/pull/1480
+      return aminoMsg.value
+    } else {
+      return aminoMsg
+    }
+  })
+
+  
+  var fixedSignDoc: any = signDoc;
+  fixedSignDoc.msgs = fixedMsgs;
+
+  return toUtf8(sortedJsonStringify(fixedSignDoc));
 }

--- a/packages/amino/src/signdoc.ts
+++ b/packages/amino/src/signdoc.ts
@@ -70,15 +70,14 @@ export function makeSignDoc(
 
 export function serializeSignDoc(signDoc: StdSignDoc): Uint8Array {
   const fixedMsgs = signDoc.msgs.map((aminoMsg) => {
-    const msg = aminoMsg;
-    if (msg.type.startsWith("regen")) {
+    if (aminoMsg.type.startsWith("regen")) {
       // regen ledger incorrectly implements amino signing.
       // this short term workaround makes cosmjs compatible with regen-ledger v4.0
       // until regen ledger upgrades with the fix in v5.0
       // ref: https://github.com/regen-network/regen-ledger/pull/1480
-      return msg.value
+      return aminoMsg.value
     } else {
-      return msg
+      return aminoMsg
     }
   })
 

--- a/packages/amino/src/signdoc.ts
+++ b/packages/amino/src/signdoc.ts
@@ -76,42 +76,11 @@ export function serializeSignDoc(signDoc: StdSignDoc): Uint8Array {
       // until regen ledger upgrades with the fix in v5.0
       // ref: https://github.com/regen-network/regen-ledger/pull/1480
 
-      console.log("unstripped item:", aminoMsg.value)
-      var foo = stripTypeFields(aminoMsg.value)
-      console.log("stripped item:", foo)
-      return foo
+      return aminoMsg.value
     } else {
       return aminoMsg
     }
   })
-
-  function stripTypeFields(msg: any): any {
-    var res: any = {};
-    for (const [key, val] of Object.entries(msg)) {
-      // if the key is '$type' we don't include it in the result
-      // relace below with "if (key != '$type' && val != ''){" to get regen-js test passing
-      if (key != '$type'){
-        var strippedValue: any;
-        if (Array.isArray(val)){
-          strippedValue = [];
-          for(const elt of val) {
-            if(typeof elt === 'object'){
-              strippedValue.push(stripTypeFields(elt))
-            } else {
-              strippedValue.push(elt)
-            }
-          }
-        } else if (typeof val === 'object'){
-          strippedValue = stripTypeFields(val)
-        } else {
-          strippedValue = val
-        }
-        
-        res[key] = strippedValue;
-      }
-    }
-    return res
-  }
   
   var fixedSignDoc = {...signDoc, msgs: fixedMsgs};
 

--- a/packages/amino/src/signdoc.ts
+++ b/packages/amino/src/signdoc.ts
@@ -70,20 +70,20 @@ export function makeSignDoc(
 
 export function serializeSignDoc(signDoc: StdSignDoc): Uint8Array {
   const fixedMsgs = signDoc.msgs.map((aminoMsg) => {
-    if (aminoMsg.type.startsWith("regen")) {
+    const msg = aminoMsg;
+    if (msg.type.startsWith("regen")) {
       // regen ledger incorrectly implements amino signing.
       // this short term workaround makes cosmjs compatible with regen-ledger v4.0
       // until regen ledger upgrades with the fix in v5.0
       // ref: https://github.com/regen-network/regen-ledger/pull/1480
-      return aminoMsg.value
+      return msg.value
     } else {
-      return aminoMsg
+      return msg
     }
   })
 
   
-  var fixedSignDoc: any = signDoc;
-  fixedSignDoc.msgs = fixedMsgs;
+  var fixedSignDoc = {...signDoc, msgs: fixedMsgs};
 
   return toUtf8(sortedJsonStringify(fixedSignDoc));
 }


### PR DESCRIPTION
This PR adds a custom serialization for amino messages that omits the type & value wrapper for Regen specific message types.

It is a workaround until https://github.com/regen-network/regen-ledger/pull/1480 get's released (targeting Regen Ledger v5.0, requiring a network upgrade).


There are a few important pieces to keep in mind when using the version of CosmJS from this PR. I was not able to get regen-js tests to pass unless these two cases were accounted for:
1. Nested `$type` fields still need to be removed. Initially the stripping of all nested `$type` fields was included in this PR, but I removed it since @mhagel found it easier to exclude these fields from the amino converters in regen-js (see https://github.com/regen-network/regen-js/pull/38#discussion_r967977551)
2. Unset/default field values in the amino converters should be set to `undefined`. Not default values (e.g. `""`, `0`, `false`) or `null`.  Since protobuf omits all default values in serialization, I believe its necessary  that we do the same for Amino converters.  In the regen-js tests, if I did not ensure this, I would still get "invalid signature" errors

